### PR TITLE
Fix fuzzer metadata handling

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -443,7 +443,9 @@ def get_all_issue_metadata(fuzz_target_path):
 
   issue_metadata = get_additional_issue_metadata(fuzz_target_path)
   if issue_metadata:
-    metadata['issue_metadata'] = issue_metadata
+    # issue_metadata is a dictionary. Treat it as string for storage purpose
+    # so that it is consistent with the definition in proto structure
+    metadata['issue_metadata'] = json.dumps(issue_metadata)
 
   return metadata
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -38,10 +38,13 @@ from clusterfuzz._internal.system import environment
 
 def _add_default_issue_metadata(testcase, fuzz_target_metadata):
   """Adds the default issue metadata (e.g. components, labels) to testcase."""
-  testcase_metadata = testcase.get_metadata()
   for key, default_value in fuzz_target_metadata.items():
     # Only string metadata are supported.
     if not isinstance(default_value, str):
+      continue
+
+    uploader_value = testcase.get_metadata(key, '')
+    if not isinstance(uploader_value, str):
       continue
 
     # Add the default issue metadata first. This gives preference to uploader
@@ -50,7 +53,6 @@ def _add_default_issue_metadata(testcase, fuzz_target_metadata):
         default_value, delimiter=',', strip=True, remove_empty=True)
 
     # Append uploader specified testcase metadata value to end (for preference).
-    uploader_value = testcase_metadata.get(key, '')
     uploader_value_list = utils.parse_delimited(
         uploader_value, delimiter=',', strip=True, remove_empty=True)
     for value in uploader_value_list:

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Classes for objects stored in the datastore."""
 
+import json
 import re
 
 from google.cloud import ndb
@@ -679,6 +680,8 @@ class Testcase(Model):
       return self.metadata_cache
 
     try:
+      if key == 'issue_metadata':
+        return json.loads(self.metadata_cache[key])
       return self.metadata_cache[key]
     except KeyError:
       return default
@@ -686,7 +689,10 @@ class Testcase(Model):
   def set_metadata(self, key, value, update_testcase=True):
     """Set metadata for a test case."""
     self._ensure_metadata_is_cached()
-    self.metadata_cache[key] = value
+    if key == 'issue_metadata' and not isinstance(value, str):
+      self.metadata_cache[key] = json.dumps(value)
+    else:
+      self.metadata_cache[key] = value
 
     self.additional_metadata = json_utils.dumps(self.metadata_cache)
     if update_testcase:

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -43,13 +43,21 @@ class AddDefaultIssueMetadataTest(unittest.TestCase):
     issue_metadata = {
         'issue_owners': 'dev1@example1.com, dev2@example2.com',
         'issue_components': 'component1',
-        'issue_labels': 'label1, label2 ,label3'
+        'issue_labels': 'label1, label2 ,label3',
+        'issue_metadata': json.dumps({
+            "assignee": "dev3@example3.com"
+        })
     }
 
     testcase = test_utils.create_generic_testcase()
     testcase.set_metadata('issue_owners', 'dev3@example3.com,dev2@example2.com')
     testcase.set_metadata('issue_components', 'component2')
     testcase.set_metadata('issue_labels', 'label4,label5, label2,')
+    testcase.set_metadata(
+        'issue_metadata',
+        {"additional_fields": {
+            'Acknowledgements': 'dev4@example4.com'
+        }})
 
     analyze_task._add_default_issue_metadata(testcase, issue_metadata)  # pylint: disable=protected-access
     self.assertEqual('dev1@example1.com,dev2@example2.com,dev3@example3.com',
@@ -58,10 +66,15 @@ class AddDefaultIssueMetadataTest(unittest.TestCase):
                      testcase.get_metadata('issue_components'))
     self.assertEqual('label1,label2,label3,label4,label5',
                      testcase.get_metadata('issue_labels'))
+    self.assertEqual({
+        "additional_fields": {
+            'Acknowledgements': 'dev4@example4.com'
+        }
+    }, testcase.get_metadata('issue_metadata'))
     self.assertEqual(3, self.mock.info.call_count)
 
   def test_no_testcase_metadata(self):
-    """Test when we only have default issue metadata and no testcase
+    """Test when we only have testcase metadata and no default issue
     metadata."""
     issue_metadata = {}
 
@@ -79,12 +92,15 @@ class AddDefaultIssueMetadataTest(unittest.TestCase):
     self.assertEqual(0, self.mock.info.call_count)
 
   def test_no_default_issue_metadata(self):
-    """Test when we only have testcase metadata and no default issue
+    """Test when we only have default issue metadata and no testcase
     metadata."""
     issue_metadata = {
         'issue_owners': 'dev1@example1.com,dev2@example2.com',
         'issue_components': 'component1',
-        'issue_labels': 'label1,label2,label3'
+        'issue_labels': 'label1,label2,label3',
+        'issue_metadata': json.dumps({
+            "assignee": "dev3@example3.com"
+        })
     }
 
     testcase = test_utils.create_generic_testcase()
@@ -95,7 +111,10 @@ class AddDefaultIssueMetadataTest(unittest.TestCase):
     self.assertEqual('component1', testcase.get_metadata('issue_components'))
     self.assertEqual('label1,label2,label3',
                      testcase.get_metadata('issue_labels'))
-    self.assertEqual(3, self.mock.info.call_count)
+    self.assertEqual({
+        "assignee": "dev3@example3.com"
+    }, testcase.get_metadata('issue_metadata'))
+    self.assertEqual(4, self.mock.info.call_count)
 
   def test_same_testcase_and_default_issue_metadata(self):
     """Test when we have same testcase metadata and default issue metadata."""

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/progression_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/progression_task_test.py
@@ -392,6 +392,12 @@ class UpdateIssueMetadataTest(unittest.TestCase):
     self.issue_metadata = {
         'issue_labels': 'label1',
         'issue_components': 'component1',
+        'issue_metadata': {
+            "assignee": "dev1@example.com",
+            "additional_fields": {
+                'Acknowledgements': 'dev4@example4.com'
+            }
+        },
     }
 
     self.testcase = data_types.Testcase(
@@ -403,28 +409,64 @@ class UpdateIssueMetadataTest(unittest.TestCase):
     """Test update issue metadata a testcase with no metadata."""
     testcase = self.testcase.key.get()
     self.assertDictEqual({
-        'issue_labels': 'label1',
-        'issue_components': 'component1',
+        'issue_labels':
+            'label1',
+        'issue_components':
+            'component1',
+        'issue_metadata':
+            json.dumps({
+                "assignee": "dev1@example.com",
+                "additional_fields": {
+                    'Acknowledgements': 'dev4@example4.com'
+                }
+            }),
     }, json.loads(testcase.additional_metadata))
 
   def test_update_issue_metadata_replace(self):
     """Test update issue metadata a testcase with different metadata."""
     self.testcase.additional_metadata = json.dumps({
-        'issue_labels': 'label1',
-        'issue_components': 'component2',
+        'issue_labels':
+            'label1',
+        'issue_components':
+            'component2',
+        'issue_metadata':
+            json.dumps({
+                "assignee": "dev1@example.com",
+                "additional_fields": {
+                    'Acknowledgements': 'dev4@example4.com'
+                }
+            }),
     })
 
     testcase = self.testcase.key.get()
     self.assertDictEqual({
-        'issue_labels': 'label1',
-        'issue_components': 'component1',
+        'issue_labels':
+            'label1',
+        'issue_components':
+            'component1',
+        'issue_metadata':
+            json.dumps({
+                "assignee": "dev1@example.com",
+                "additional_fields": {
+                    'Acknowledgements': 'dev4@example4.com'
+                }
+            }),
     }, json.loads(testcase.additional_metadata))
 
   def test_update_issue_metadata_same(self):
     """Test update issue metadata a testcase with the same metadata."""
     self.testcase.additional_metadata = json.dumps({
-        'issue_labels': 'label1',
-        'issue_components': 'component1',
+        'issue_labels':
+            'label1',
+        'issue_components':
+            'component1',
+        'issue_metadata':
+            json.dumps({
+                "assignee": "dev1@example.com",
+                "additional_fields": {
+                    'Acknowledgements': 'dev4@example4.com'
+                }
+            }),
     })
     self.testcase.put()
 
@@ -432,8 +474,17 @@ class UpdateIssueMetadataTest(unittest.TestCase):
 
     testcase = self.testcase.key.get()
     self.assertDictEqual({
-        'issue_labels': 'label1',
-        'issue_components': 'component1',
+        'issue_labels':
+            'label1',
+        'issue_components':
+            'component1',
+        'issue_metadata':
+            json.dumps({
+                "assignee": "dev1@example.com",
+                "additional_fields": {
+                    'Acknowledgements': 'dev4@example4.com'
+                }
+            }),
     }, json.loads(testcase.additional_metadata))
     self.assertIsNone(testcase.crash_type)
 


### PR DESCRIPTION
The `issue_metadata` object in the uworker_msg `Output` protobuf is of type `map<string,string>`. But the actual fuzzer metadata is heterogeneous (contains string, dictionary, etc.).