### PR TITLE
Resolve TypeError during FuzzContext creation

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -419,7 +419,8 @@ def get_additional_issue_metadata(fuzz_target_path):
 
   with open(metadata_file_path) as handle:
     try:
-      return json.load(handle)
+      metadata = json.load(handle)
+      return json.dumps(metadata)
     except (ValueError, TypeError):
       logs.error('Invalid metadata file format.', path=metadata_file_path)
       return {}


### PR DESCRIPTION
This PR aims to resolve the following error:
`TypeError: bad argument type for built-in operation`

The value of `fuzzer_metadata` for the key `'issue_metadata'` is a `dict`, it should be a `str`.