### PR TITLE
Improve Cuttlefish boot reliability with stable build fallback

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -23,6 +23,14 @@ BIG_QUERY_WRITE_COUNT = monitor.CounterMetric(
         monitor.BooleanField('success'),
     ])
 
+CF_TIP_BOOT_FAILED_COUNT = monitor.CounterMetric(
+    'tip_boot_failure',
+    description=
+    'Count of failure in booting up cuttlefish with tip-of-the-tree build ',
+    field_spec=[
+        monitor.StringField('build_id'),
+    ])
+
 JOB_BAD_BUILD_COUNT = monitor.CounterMetric(
     'task/fuzz/job/bad_build_count',
     description=("Count of fuzz task's bad build count "

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -201,7 +201,7 @@ def get_stable_build_info():
   return stable_build_info
 
 
-def get_latest_artifact_info(branch, target, signed=False):
+def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
   """Return latest artifact for a branch and target."""
   client = get_client()
   if not client:
@@ -209,7 +209,7 @@ def get_latest_artifact_info(branch, target, signed=False):
 
   # TODO(https://github.com/google/clusterfuzz/issues/3950)
   # After stabilizing the Cuttlefish image, revert this
-  if environment.is_android_cuttlefish():
+  if environment.is_android_cuttlefish() and stable_build:
     build_info = get_stable_build_info()
     # Use tip-of-tree build if 'bid' is missing or 0.
     # Setting 'bid' to 0 in stable_build_info.json

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -21,6 +21,7 @@ from clusterfuzz._internal.base import dates
 from clusterfuzz._internal.base import persistent_cache
 from clusterfuzz._internal.datastore import locks
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.system import archive
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.system import shell
@@ -88,6 +89,15 @@ def download_latest_build(build_info, image_regexes, image_directory):
       if file_path.endswith('.zip') or file_path.endswith('.tar.gz'):
         with archive.open(file_path) as reader:
           reader.extract_all(image_directory)
+
+
+def boot_stable_build_cuttlefish(branch, target, image_directory):
+  """Boot cuttlefish instance using stable build id fetched from gcs."""
+  build_info = fetch_artifact.get_latest_artifact_info(
+      branch, target, stable_build=True)
+  download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES, image_directory)
+  adb.recreate_cuttlefish_device()
+  adb.connect_to_cuttlefish_device()
 
 
 def flash_to_latest_build_if_needed():
@@ -206,8 +216,18 @@ def flash_to_latest_build_if_needed():
     locks.release_lock(flash_lock_key_name, by_zone=True)
 
   if adb.get_device_state() != 'device':
-    logs.error('Unable to find device. Reimaging failed.')
-    adb.bad_state_reached()
+    if environment.is_android_cuttlefish():
+      logs.info('Trying to boot cuttlefish instance using stable build.')
+      monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
+          'build_id': build_info['bid']
+      })
+      boot_stable_build_cuttlefish(branch, target, image_directory)
+      if adb.get_device_state() != 'device':
+        logs.error('Unable to find device. Reimaging failed.')
+        adb.bad_state_reached()
+    else:
+      logs.error('Unable to find device. Reimaging failed.')
+      adb.bad_state_reached()
 
   logs.info('Reimaging finished.')
 


### PR DESCRIPTION
This commit modifies the `flash_to_latest_build_if_needed` function to include a fallback mechanism for booting Cuttlefish. If the device fails to boot using the tip-of-the-tree build, the system will now attempt to boot using a stable build retrieved from GCS. Also, added cuttlefish tip-of-the-tree boot up failure metric for alerting mechanism.