### PR TITLE
Skip 'rsync_from_disk()' call if the quarantine corpus is empty

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -699,7 +699,8 @@ def do_corpus_pruning(uworker_input, context, revision) -> CorpusPruningResult:
   # Mapping of crash state -> CrashInfo
   crashes = pruner.process_bad_units(context.bad_units_path,
                                      context.quarantine_corpus_path)
-  context.quarantine_corpus.rsync_from_disk(context.quarantine_corpus_path)
+  if shell.get_directory_file_count(context.quarantine_corpus_path):
+    context.quarantine_corpus.rsync_from_disk(context.quarantine_corpus_path)
 
   # Store corpus stats into CoverageInformation entity.
   project_qualified_name = context.fuzz_target.project_qualified_name()


### PR DESCRIPTION
We noticed an increase in fuzzers failing in the Coverage Client Job. We observed that the major cause was a failure during corpus pruning. Calling 'rsync_from_disk()' with an [empty quarantine corpus](https://github.com/google/clusterfuzz/blob/master/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py#L702) leads to trigger [unintended assertion](https://github.com/google/clusterfuzz/blob/master/src/clusterfuzz/_internal/fuzzing/corpus_manager.py#L442) in the corpus pruning job, which subsequently causes the Coverage Client Job to fail. To address this, we now skip the '[rsync_from_disk()](https://github.com/google/clusterfuzz/blob/master/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py#L702)' call if the quarantine corpus is empty, preventing unnecessary failures.