### PR TITLE
Restore cuttlefish fuzzing by ensuring platform initialization runs

### DIFF
--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -124,6 +124,10 @@ def task_loop():
         # so that utasks can't be updated on subsequent attempts.
         update_task.run()
         update_task.track_revision()
+      else:
+        logs.info("Update task not enabled. Running platform init scripts.")
+        update_task.run_platform_init_scripts()
+
       if environment.is_uworker():
         # Batch/Swarming tasks only run one at a time.
         sys.exit(utasks.uworker_bot_main())


### PR DESCRIPTION
Due to skipped call to `update_task.run()` when the update task was not enabled. The `run_platform_init_scripts()` function, which is critical for booting up the Cuttlefish AVD device, was being bypassed. This resulted in fuzzing drops due to the device failing to start. Following change ensures run_platform_init_scripts()' is called even if update task in not enabled