### PR TITLE
Skip appending 'next' to target

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -58,7 +58,9 @@ PRODUCT_TO_KERNEL = {
 
 RELEASE_CONFIGURATION = 'next'
 
-NO_RELEASE_CONFIGURATION_TARGET_LIST = ['shiba_fullmte', 'husky_fullmte', 'komodo_fullmte']
+NO_RELEASE_CONFIGURATION_TARGET_LIST = [
+    'shiba_fullmte', 'husky_fullmte', 'komodo_fullmte'
+]
 
 DEPRECATED_DEVICE_LIST = [
     'sailfish',  # Pixel

--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -58,7 +58,7 @@ PRODUCT_TO_KERNEL = {
 
 RELEASE_CONFIGURATION = 'next'
 
-NO_RELEASE_CONFIGURATION_TARGET_LIST = ['shiba_fullmte', 'husky_fullmte']
+NO_RELEASE_CONFIGURATION_TARGET_LIST = ['shiba_fullmte', 'husky_fullmte', 'komodo_fullmte']
 
 DEPRECATED_DEVICE_LIST = [
     'sailfish',  # Pixel


### PR DESCRIPTION
Avoid appending 'next-' to the 'komodo_fullmte' target to prevent inaccurate querying of AB/API.