### PR TITLE
Resolve 'TypeError' in _setup_split_targets_build()

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1151,7 +1151,7 @@ def _setup_split_targets_build(bucket_path, fuzz_target, revision=None):
 
   # Check this so that we handle deleted targets properly.
   targets_list = _get_targets_list(bucket_path)
-  if fuzz_target not in targets_list:
+  if not targets_list or fuzz_target not in targets_list:
     raise errors.BuildNotFoundError(revision, environment.get_value('JOB_NAME'))
 
   fuzz_target_bucket_path = _full_fuzz_target_path(bucket_path, fuzz_target)

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -1731,6 +1731,12 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
         os.environ['FUZZ_TARGET_BUILD_BUCKET_PATH'])
     self.assertCountEqual(['target1', 'target3'], targets_list)
 
+  def test_setup_split_build_no_targets_list(self):
+    """Test that BuildNotFoundError is raised when the targets list is missing."""
+    self.mock.read_data.return_value = None
+    with self.assertRaises(errors.BuildNotFoundError):
+      build_manager.setup_build(fuzz_target='target3')
+
   def test_target_no_longer_built(self):
     """Test a target that's not longer listed in target.list."""
     test_helpers.patch(self, [


### PR DESCRIPTION
This change addresses a `TypeError` in `_setup_split_targets_build()`. [The error](https://pantheon.corp.google.com/errors/detail/CNbfppvCxoWiyAE;locations=global?project=google.com:cluster-fuzz) arises when `_get_targets_list()` returns `None`, because there is an attempt to check for `fuzz_target` in a `NoneType` object. To fix this, a separate check has been introduced to verify that `targets_list` is not `None` before it is iterated over.