### PR TITLE
Resolve SIGILL errors on Pixel 6 devices caused by a binary mismatch

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -394,7 +394,8 @@ def get_task():
                 f'job {task.job} from {regular_queue()} queue.')
       return task
 
-    if environment.is_android():
+    # Restrict PIXEL6 devices from picking up tasks from default_android_queue.
+    if environment.is_android() and environment.platform() != 'ANDROID:PIXEL6':
       logs.info(f'Could not get task from {regular_queue()}. Trying from'
                 f'default android queue {default_android_queue()}.')
       task = get_regular_task(default_android_queue())

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -395,16 +395,21 @@ def get_task():
                 f'job {task.job} from {regular_queue()} queue.')
       return task
 
-    if environment.is_android() and environment.platform() not in \
-        constants.DEVICES_WITH_NO_FALLBACK_QUEUE_LIST:
-      logs.info(f'Could not get task from {regular_queue()}. Trying from'
-                f'default android queue {default_android_queue()}.')
-      task = get_regular_task(default_android_queue())
-      if task:
-        # Log the task details for debug purposes.
-        logs.info(f'Got task with cmd {task.command} args {task.argument} '
-                  f'job {task.job} from {default_android_queue()} queue.')
-        return task
+    if environment.is_android():
+      if environment.platform() not in \
+      constants.DEVICES_WITH_NO_FALLBACK_QUEUE_LIST:
+        logs.info(f'Could not get task from {regular_queue()}. Trying from'
+                  f'default android queue {default_android_queue()}.')
+        task = get_regular_task(default_android_queue())
+        if task:
+          # Log the task details for debug purposes.
+          logs.info(f'Got task with cmd {task.command} args {task.argument} '
+                    f'job {task.job} from {default_android_queue()} queue.')
+          return task
+      else:
+        logs.info(f'{environment.platform()} is part of devices with no '
+                  f'fallback list. Hence skipping picking up tasks from '
+                  f'default {default_android_queue()} queue.')
 
   logs.info(f'Could not get task from {regular_queue()}. Fuzzing.')
 

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -34,6 +34,7 @@ from clusterfuzz._internal.fuzzing import fuzzer_selection
 from clusterfuzz._internal.google_cloud_utils import pubsub
 from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.platforms.android import constants
 from clusterfuzz._internal.system import environment
 
 # Task queue prefixes for various job types.
@@ -394,8 +395,8 @@ def get_task():
                 f'job {task.job} from {regular_queue()} queue.')
       return task
 
-    # Restrict PIXEL6 devices from picking up tasks from default_android_queue.
-    if environment.is_android() and environment.platform() != 'ANDROID:PIXEL6':
+    if environment.is_android() and environment.platform() not in \
+        constants.DEVICES_WITH_NO_FALLBACK_QUEUE_LIST:
       logs.info(f'Could not get task from {regular_queue()}. Trying from'
                 f'default android queue {default_android_queue()}.')
       task = get_regular_task(default_android_queue())

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -154,7 +154,12 @@ def get_fuzz_task_payload(platform=None):
   if not mappings:
     return None, None
 
-  selected_mappings = mappings
+  # Restrict PIXEL6 bots to Pixel6-specific jobs. This prevents them from
+  # receiving generic Android jobs that lead to Binary Mismatch issue.
+  if 'PIXEL6' in platform:
+    selected_mappings = [m for m in mappings if 'pixel6' in m.job.lower()]
+  else:
+    selected_mappings = mappings
   # The environment variable containing a list of comma-separated jobs.
   # E.g: "libfuzzer_asan_android_host,afl_asan_android_host,..."
   jobs_selection = environment.get_value('HOST_JOB_SELECTION')

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -137,9 +137,13 @@ def get_fuzz_task_payload(platform=None):
 
   # Conditionally append the base platform (e.g. ANDROID) as a job filter,
   # unless the platform is restricted or is the base platform itself.
-  if platform != base_platform and platform not in \
-      constants.DEVICES_WITH_NO_FALLBACK_QUEUE_LIST:
-    platforms.append(base_platform)
+  if platform != base_platform:
+    if platform not in constants.DEVICES_WITH_NO_FALLBACK_QUEUE_LIST:
+      platforms.append(base_platform)
+    else:
+      logs.info(f'{platform} is part of devices with no fallback list. '
+                f'Hence skipping inclusion of the generic platform '
+                f'({base_platform}) while querying.')
 
   if environment.is_production():
     query = data_types.FuzzerJobs.query()

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -157,7 +157,8 @@ def get_fuzz_task_payload(platform=None):
   # Restrict PIXEL6 bots to Pixel6-specific jobs. This prevents them from
   # receiving generic Android jobs that lead to Binary Mismatch issue.
   if 'PIXEL6' in platform:
-    selected_mappings = [m for m in mappings if 'pixel6' in m.job.lower()]
+    selected_mappings = list(
+        filter(lambda m: 'pixel6' in m.job.lower(), mappings))
   else:
     selected_mappings = mappings
   # The environment variable containing a list of comma-separated jobs.

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -22,14 +22,11 @@ from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.datastore import fuzz_target_utils
 from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.platforms.android import constants
 from clusterfuzz._internal.system import environment
 
 # Used to prepare targets to be passed to utils.random_weighted_choice.
 WeightedTarget = collections.namedtuple('WeightedTarget', ['target', 'weight'])
-
-# Restrict pixel6 from picking up generic Android jobs to avoid
-# Binary Mismatch
-restricted_platforms = ['ANDROID:PIXEL6']
 
 
 def update_mappings_for_fuzzer(fuzzer, mappings=None):
@@ -137,11 +134,11 @@ def get_fuzz_task_payload(platform=None):
 
   platforms = [platform]
   base_platform = platform.split(':')[0]
-  restricted_platforms.append(base_platform)
 
   # Conditionally append the base platform (e.g. ANDROID) as a job filter,
   # unless the platform is restricted or is the base platform itself.
-  if platform not in restricted_platforms:
+  if platform != base_platform and platform not in \
+      constants.DEVICES_WITH_NO_FALLBACK_QUEUE_LIST:
     platforms.append(base_platform)
 
   if environment.is_production():

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -134,7 +134,7 @@ def get_fuzz_task_payload(platform=None):
   platforms = [platform]
   base_platform = platform.split(':')[0]
   # Generalized queue for platforms with a base platform (e.g. ANDROID)
-  if base_platform != platform:
+  if base_platform != platform and platform != 'ANDROID:PIXEL6':
     platforms.append(base_platform)
 
   if environment.is_production():
@@ -154,13 +154,7 @@ def get_fuzz_task_payload(platform=None):
   if not mappings:
     return None, None
 
-  # Restrict PIXEL6 bots to Pixel6-specific jobs. This prevents them from
-  # receiving generic Android jobs that lead to Binary Mismatch issue.
-  if 'PIXEL6' in platform:
-    selected_mappings = list(
-        filter(lambda m: 'pixel6' in m.job.lower(), mappings))
-  else:
-    selected_mappings = mappings
+  selected_mappings = mappings
   # The environment variable containing a list of comma-separated jobs.
   # E.g: "libfuzzer_asan_android_host,afl_asan_android_host,..."
   jobs_selection = environment.get_value('HOST_JOB_SELECTION')

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -134,7 +134,7 @@ def get_fuzz_task_payload(platform=None):
   platforms = [platform]
   base_platform = platform.split(':')[0]
   # Generalized queue for platforms with a base platform (e.g. ANDROID)
-  if base_platform != platform and platform != 'ANDROID:PIXEL6':
+  if platform not in (base_platform, 'ANDROID:PIXEL6'):
     platforms.append(base_platform)
 
   if environment.is_production():

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -27,6 +27,10 @@ from clusterfuzz._internal.system import environment
 # Used to prepare targets to be passed to utils.random_weighted_choice.
 WeightedTarget = collections.namedtuple('WeightedTarget', ['target', 'weight'])
 
+# Restrict pixel6 from picking up generic Android jobs to avoid
+# Binary Mismatch
+restricted_platforms = ['ANDROID:PIXEL6']
+
 
 def update_mappings_for_fuzzer(fuzzer, mappings=None):
   """Clear existing mappings for a fuzzer, and replace them."""
@@ -133,8 +137,11 @@ def get_fuzz_task_payload(platform=None):
 
   platforms = [platform]
   base_platform = platform.split(':')[0]
-  # Generalized queue for platforms with a base platform (e.g. ANDROID)
-  if platform not in (base_platform, 'ANDROID:PIXEL6'):
+  restricted_platforms.append(base_platform)
+
+  # Conditionally append the base platform (e.g. ANDROID) as a job filter,
+  # unless the platform is restricted or is the base platform itself.
+  if platform not in restricted_platforms:
     platforms.append(base_platform)
 
   if environment.is_production():

--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -82,3 +82,7 @@ DEPRECATED_DEVICE_LIST = [
     'redfin',  # Pixel 5
     'barbet',  # Pixel 5a
 ]
+
+# Restrict pixel6 from picking up generic Android jobs to avoid
+# Binary Mismatch: Hence, 'ANDROID:PIXEL6' is added to the list.
+DEVICES_WITH_NO_FALLBACK_QUEUE_LIST = ['ANDROID:PIXEL6']


### PR DESCRIPTION
Filter fuzzing jobs to ensure Pixel 6 compatibility for Pixel 6 devices. Prevent Pixel 6 devices from falling back to the generic `jobs-android` queue.