### PR TITLE
Resolve AttributeError in issue_filer.py

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -327,7 +327,8 @@ def file_issue(testcase,
 
   issue = issue_tracker.new_issue()
   if issue_tracker.project == 'google-buganizer':
-    logs.info(f"New issue's default component id = {issue.component_id}")
+    default_component_id = getattr(issue, 'component_id', None)
+    logs.info(f"New issue's default component id = {default_component_id}")
   issue.title = data_handler.get_issue_summary(testcase)
   issue.body = data_handler.get_issue_description(
       testcase, reporter=user_email, show_reporter=True)
@@ -492,8 +493,10 @@ def file_issue(testcase,
     if issue_tracker.project == 'google-buganizer':
       logs.info('The values of Component IDs:')
       logs.info(f'1. Backing: {list(issue.components)}')
-      logs.info(f'2. Removed: {list(issue.components.removed)}')
-      logs.info(f'3. Added: {list(issue.components.added)}')
+      removed = list(getattr(issue.components, 'removed', None))
+      logs.info(f'2. Removed: {removed}')
+      added = list(getattr(issue.components, 'added', None))
+      logs.info(f'3. Added: {added}')
     logs.info('Primary attempt to the save the issue.')
     issue.save()
   except Exception as e:


### PR DESCRIPTION
Safeguard the process of issue filing by ensuring the presence of attributes within `Issue` variants before accessing them.

This issue occurs due to the changes made in #5074. #5074 adds debugging logs, and one of the logs tries to access an attribute (`component_id`) of a class (`Issue`), resulting in the following error:
**'Issue' object has no attribute 'component_id'**

This issue has blocked the issue filing process.

The current changes aim to resolve this issue using `getattr()` which checks if an attribute exists and only then accesses it.