### PR TITLE
Fix Cuttlefish helper process leak on unresponsive ADB teardown

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -54,6 +54,10 @@ STOP_CVD_WAIT = 20
 LAUNCH_CVD_TIMEOUT = 2700
 CMD_KILL_CROSVM = 'pkill crosvm'
 CMD_KILL_RUN_CVD = 'pkill run_cvd'
+CMD_KILL_TOMBSTONE_RECEIVER = 'pkill tombstone_receiver'
+CMD_KILL_SOCKET_VSOCK_PROXY = 'pkill socket_vsock_proxy'
+CMD_KILL_LOGCAT_RECEIVER = 'pkill logcat_receiver'
+CMD_KILL_MODEM_SIMULATOR = 'pkill modem_simulator'
 
 # Output patterns to parse "lsusb" output.
 LSUSB_BUS_RE = re.compile(r'Bus\s+(\d+)\s+Device\s+(\d+):.*')
@@ -445,15 +449,36 @@ def stop_cuttlefish_device():
   stop_cvd_cmd = os.path.join(cvd_bin_dir, 'stop_cvd')
   logs.info('stop_cvd_cmd: %s' % str(stop_cvd_cmd))
 
-  if get_device_state() == 'device':
+  # Attempt a graceful shutdown.
+  try:
     execute_command(
         stop_cvd_cmd, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
     time.sleep(STOP_CVD_WAIT)
+  except Exception as e:
+    logs.warning('Graceful stop_cvd failed or timed out: %s' % str(e))
 
+  # Forcefully kill crosvm, run_cvd and all CVD helper processes to prevent
+  # port leaks.
   execute_command(
       CMD_KILL_CROSVM, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
   execute_command(
       CMD_KILL_RUN_CVD, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
+  execute_command(
+      CMD_KILL_TOMBSTONE_RECEIVER,
+      timeout=RECOVERY_CMD_TIMEOUT,
+      on_cuttlefish_host=True)
+  execute_command(
+      CMD_KILL_SOCKET_VSOCK_PROXY,
+      timeout=RECOVERY_CMD_TIMEOUT,
+      on_cuttlefish_host=True)
+  execute_command(
+      CMD_KILL_LOGCAT_RECEIVER,
+      timeout=RECOVERY_CMD_TIMEOUT,
+      on_cuttlefish_host=True)
+  execute_command(
+      CMD_KILL_MODEM_SIMULATOR,
+      timeout=RECOVERY_CMD_TIMEOUT,
+      on_cuttlefish_host=True)
 
 
 def restart_cuttlefish_device():

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -53,11 +53,6 @@ GET_DEVICE_STATE_TIMEOUT = 20
 STOP_CVD_WAIT = 20
 LAUNCH_CVD_TIMEOUT = 2700
 CMD_KILL_CROSVM = 'pkill crosvm'
-CMD_KILL_RUN_CVD = 'pkill run_cvd'
-CMD_KILL_TOMBSTONE_RECEIVER = 'pkill tombstone_receiver'
-CMD_KILL_SOCKET_VSOCK_PROXY = 'pkill socket_vsock_proxy'
-CMD_KILL_LOGCAT_RECEIVER = 'pkill logcat_receiver'
-CMD_KILL_MODEM_SIMULATOR = 'pkill modem_simulator'
 
 # Output patterns to parse "lsusb" output.
 LSUSB_BUS_RE = re.compile(r'Bus\s+(\d+)\s+Device\s+(\d+):.*')
@@ -457,28 +452,13 @@ def stop_cuttlefish_device():
   except Exception as e:
     logs.warning('Graceful stop_cvd failed or timed out: %s' % str(e))
 
-  # Forcefully kill crosvm, run_cvd and all CVD helper processes to prevent
-  # port leaks.
+  # Forcefully kill crosvm and all CVD helper processes to prevent port leaks.
   execute_command(
       CMD_KILL_CROSVM, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
+
+  kill_helpers_cmd = f'pkill -f "{cvd_bin_dir}/"'
   execute_command(
-      CMD_KILL_RUN_CVD, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
-  execute_command(
-      CMD_KILL_TOMBSTONE_RECEIVER,
-      timeout=RECOVERY_CMD_TIMEOUT,
-      on_cuttlefish_host=True)
-  execute_command(
-      CMD_KILL_SOCKET_VSOCK_PROXY,
-      timeout=RECOVERY_CMD_TIMEOUT,
-      on_cuttlefish_host=True)
-  execute_command(
-      CMD_KILL_LOGCAT_RECEIVER,
-      timeout=RECOVERY_CMD_TIMEOUT,
-      on_cuttlefish_host=True)
-  execute_command(
-      CMD_KILL_MODEM_SIMULATOR,
-      timeout=RECOVERY_CMD_TIMEOUT,
-      on_cuttlefish_host=True)
+      kill_helpers_cmd, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
 
 
 def restart_cuttlefish_device():


### PR DESCRIPTION
The Cuttlefish teardown routine bypasses the graceful `stop_cvd` command when Cuttlefish freezes, hangs, or when the `ADB` connection goes offline, proceeding to force-kill only `crosvm` and `run_cvd`. This leaks helper processes like `tombstone_receiver` and `socket_vsock_proxy`, leaving TCP ports bound indefinitely and causing subsequent boot attempts to fail with `Address already in use` errors.

This change ensures `stop_cvd` is always attempted gracefully and force-kills remaining CVD helper processes in the fallback path to guarantee clean port release.